### PR TITLE
Update packages and fix version capabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,19 +22,20 @@
   },
   "dependencies": {
     "bowser": "^2.11.0",
-    "core-js": "3.13.1",
+    "core-js": "^3.14.0",
     "custom-event-polyfill": "^1.0.7",
-    "element-closest-polyfill": "1.0.4",
-    "es6-object-assign": "1.1.0",
+    "element-closest-polyfill": "^1.0.4",
+    "es6-object-assign": "^1.1.0",
     "jspolyfill-array.prototype.find": "^0.1.3",
-    "object-fit-images": "3.2.4",
-    "object-fit-videos": "1.0.4",
-    "picturefill": "3.0.3",
-    "svg4everybody": "2.1.9",
-    "whatwg-fetch": "3.6.2"
+    "object-fit-images": "^3.2.4",
+    "object-fit-videos": "^1.0.4",
+    "picturefill": "^3.0.3",
+    "svg4everybody": "^2.1.9",
+    "whatwg-fetch": "^3.6.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.3",
+    "@babel/core": "^7.14.3",
     "@babel/preset-env": "^7.14.4",
     "rimraf": "^3.0.2"
   }

--- a/src/capabilities.js
+++ b/src/capabilities.js
@@ -20,7 +20,9 @@ const capabilities = {
   os: browser.getOSName(true),
   engine: browser.getEngineName(true),
   name: name,
-  version: browser.getBrowserVersion().split('.')[0],
+  version: typeof browser.getBrowserVersion() === 'string' 
+    ? browser.getBrowserVersion().split('.')[0] 
+    : '0',
   chrome: (name === 'chrome'),
   opera: (name === 'opera'),
   firefox: (name === 'firefox'),


### PR DESCRIPTION
Add @babel/config packages for old node version 
Fix version capabilities (if `browser.getBrowserVersion()` is undefined)